### PR TITLE
Fix tracking issue number for feature(macro_attr)

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -554,7 +554,7 @@ declare_features! (
     /// Allows fused `loop`/`match` for direct intraprocedural jumps.
     (incomplete, loop_match, "1.90.0", Some(132306)),
     /// Allow `macro_rules!` attribute rules
-    (unstable, macro_attr, "CURRENT_RUSTC_VERSION", Some(83527)),
+    (unstable, macro_attr, "CURRENT_RUSTC_VERSION", Some(143547)),
     /// Allow `macro_rules!` derive rules
     (unstable, macro_derive, "CURRENT_RUSTC_VERSION", Some(143549)),
     /// Give access to additional metadata about declarative macro meta-variables.


### PR DESCRIPTION
The ability to define an attribute macro with `macro_rules!` is tracked at https://github.com/rust-lang/rust/issues/143547, not https://github.com/rust-lang/rust/issues/83527